### PR TITLE
Initialize nf-test with cNMF smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 
+# Local nf-test artifacts
+/.nf-test/
+/.nf-test.log
+/tests/.cache/

--- a/nf-test.config
+++ b/nf-test.config
@@ -1,0 +1,11 @@
+/*
+ * nf-test runner configuration.
+ *
+ * Keep this file limited to nf-test settings. Nextflow runtime overrides for
+ * tests live in tests/nextflow/config/*/*.config so production profiles under conf/
+ * stay untouched and tests/ can also host other test systems such as pytest.
+ */
+config {
+    testsDir "tests/nextflow"
+    workDir ".nf-test"
+}

--- a/tests/nextflow/cnmf_smoke.nf.test
+++ b/tests/nextflow/cnmf_smoke.nf.test
@@ -1,0 +1,16 @@
+// nf-test smoke: invoke cnmf's CLI and assert the program output contract.
+nextflow_process {
+
+    name "cnmf smoke"
+    script "tests/nextflow/modules/cnmf_smoke.nf"
+    process "CNMF_SMOKE"
+    config "tests/nextflow/config/params/cnmf_smoke.config"
+
+    test("cnmf smoke pipeline yields K=5 consensus outputs") {
+        then {
+            assert process.success
+            assert path(process.out.spectra.get(0)).exists()   // genes x K
+            assert path(process.out.usages.get(0)).exists()    // cells x K
+        }
+    }
+}

--- a/tests/nextflow/config/params/cnmf_smoke.config
+++ b/tests/nextflow/config/params/cnmf_smoke.config
@@ -1,0 +1,25 @@
+/*
+========================================================================================
+    Parameters for the cNMF smoke nf-test.
+========================================================================================
+
+    This is the test-case config entrypoint: it imports the shared local nf-test runtime
+    config, then defines the cNMF smoke inputs. The values are intentionally tiny: this
+    test checks CLI wiring and output contract, not biology.
+*/
+
+includeConfig "${projectDir}/tests/nextflow/config/runtime/local.config"
+
+params {
+    rn_runname = 'cnmf_smoke'
+
+    cnmf_smoke {
+        k = 5
+        n_iter = 10
+        numgenes = 50
+        seed = 0
+        worker_index = 0
+        total_workers = 1
+        local_density_threshold = 2.0
+    }
+}

--- a/tests/nextflow/config/runtime/local.config
+++ b/tests/nextflow/config/runtime/local.config
@@ -1,0 +1,27 @@
+/*
+========================================================================================
+    Shared local Nextflow runtime config for nf-test runs.
+========================================================================================
+
+    This is test-harness config, not a production execution profile. Keep LSF/FARM,
+    publishing, scratch, and large resource behavior out of nf-test unless a specific
+    integration test needs it.
+*/
+
+process {
+    executor = 'local'
+    maxRetries = 0
+    errorStrategy = 'terminate'
+    cpus = 1
+    memory = 2.GB
+    time = 30.min
+}
+
+executor {
+    queueSize = 2
+}
+
+params {
+    rn_scratch = false
+    rn_publish_dir = 'tests/.cache/publish'
+}

--- a/tests/nextflow/modules/cnmf_smoke.nf
+++ b/tests/nextflow/modules/cnmf_smoke.nf
@@ -1,0 +1,41 @@
+// Test-only smoke module: invoke cnmf's CLI path (prepare -> factorize -> combine -> consensus).
+// It uses params.rn_runname as cNMF's --name, matching sc-blipper's cnmf process contract.
+nextflow.enable.dsl = 2
+
+process CNMF_SMOKE {
+    conda "${projectDir}/environment.yml"
+
+    output:
+    path "${params.rn_runname}/cnmf_tmp/*.spectra.k_*.dt_*.consensus.df.npz", emit: spectra
+    path "${params.rn_runname}/cnmf_tmp/*.usages.k_*.dt_*.consensus.df.npz",  emit: usages
+
+    script:
+    """
+    python ${projectDir}/tests/nextflow/scripts/make_tiny_counts.py counts.h5ad
+
+    cnmf prepare \
+        --output-dir ./ \
+        --name ${params.rn_runname} \
+        -c counts.h5ad \
+        -k ${params.cnmf_smoke.k} \
+        --n-iter ${params.cnmf_smoke.n_iter} \
+        --numgenes ${params.cnmf_smoke.numgenes} \
+        --seed ${params.cnmf_smoke.seed}
+
+    cnmf factorize \
+        --output-dir ./ \
+        --name ${params.rn_runname} \
+        --worker-index ${params.cnmf_smoke.worker_index} \
+        --total-workers ${params.cnmf_smoke.total_workers}
+
+    cnmf combine \
+        --output-dir ./ \
+        --name ${params.rn_runname}
+
+    cnmf consensus \
+        --output-dir ./ \
+        --name ${params.rn_runname} \
+        --components ${params.cnmf_smoke.k} \
+        --local-density-threshold ${params.cnmf_smoke.local_density_threshold}
+    """
+}

--- a/tests/nextflow/scripts/make_tiny_counts.py
+++ b/tests/nextflow/scripts/make_tiny_counts.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Generate a tiny synthetic raw-count .h5ad for the cnmf_smoke nf-test."""
+
+import sys
+
+import anndata as ad
+import numpy as np
+import scipy.sparse as sp
+
+
+out = sys.argv[1] if len(sys.argv) > 1 else "counts.h5ad"
+rng = np.random.default_rng(42)
+X = rng.poisson(
+    rng.gamma(1.0, size=(200, 3)) @ rng.gamma(1.0, size=(3, 60))
+).astype("float32")
+
+a = ad.AnnData(sp.csr_matrix(X))
+a.obs_names = [f"c{i}" for i in range(200)]
+a.var_names = [f"g{j}" for j in range(60)]
+a.write(out)


### PR DESCRIPTION
## Summary

  Adds the initial nf-test setup for sc-blipper with a focused cNMF smoke test.

  The test runs the cNMF CLI path end to end on a tiny synthetic `.h5ad` input:

  - `cnmf prepare`
  - `cnmf factorize`
  - `cnmf combine`
  - `cnmf consensus`

  It then checks that consensus spectra and usages outputs are produced for `K=5`.

  ## Changes

  - Add root `nf-test.config` for nf-test runner settings.
  - Add `tests/nextflow/` layout for Nextflow tests.
  - Add separate runtime and parameter configs:
    - `tests/nextflow/config/runtime/local.config`
    - `tests/nextflow/config/params/cnmf_smoke.config`
  - Add a test-only cNMF smoke process module.
  - Add a small Python helper to generate synthetic count data.
  - Ignore local nf-test artifacts.

  ## Test

  ```bash
  nf-test test tests/nextflow/cnmf_smoke.nf.test