### PR TITLE
Fix extra quote in AWK ID-link inversion command

### DIFF
--- a/processes/utils.nf
+++ b/processes/utils.nf
@@ -34,7 +34,7 @@ process invert_id_link {
     script:
     """
     outfile="\$(basename ${id_linker} | sed 's/.tsv//g')"
-    awk '{print \$2"\t"\$1"}' ${id_linker} > \${outfile}_inverted.tsv
+    awk '{print \$2"\t"\$1}' ${id_linker} > \${outfile}_inverted.tsv
     """
 }
 


### PR DESCRIPTION
Removes an extra quote from the invert_id_link AWK command that caused gene ID-link inversion to fail